### PR TITLE
added SSL request and SASL auth messages

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -10,9 +10,14 @@ type AuthenticationMethod int
 
 // Available authentication methods
 const (
-	AuthenticationMethodOK        AuthenticationMethod = 0
-	AuthenticationMethodPlaintext AuthenticationMethod = 3
-	AuthenticationMethodMD5       AuthenticationMethod = 5
+	AuthenticationMethodOK           AuthenticationMethod = 0
+	AuthenticationMethodPlaintext    AuthenticationMethod = 3
+	AuthenticationMethodMD5          AuthenticationMethod = 5
+	AuthenticationMethodSASL         AuthenticationMethod = 10
+	AuthenticationMethodSASLContinue AuthenticationMethod = 11
+	AuthenticationMethodSASLFinal    AuthenticationMethod = 12
+	SASLMechanismScramSHA256                              = "SCRAM-SHA-256"
+	SASLMechanismScramSHA256Plus                          = "SCRAM-SHA-256-PLUS"
 )
 
 func (a AuthenticationMethod) String() string {
@@ -23,6 +28,8 @@ func (a AuthenticationMethod) String() string {
 		return "Plaintext"
 	case AuthenticationMethodMD5:
 		return "MD5"
+	case AuthenticationMethodSASL:
+		return "SASL"
 	}
 
 	return "Unknown"
@@ -31,8 +38,11 @@ func (a AuthenticationMethod) String() string {
 // AuthenticationRequest is a server response either asking the client to authenticate or
 // used to indicate that authentication was successful
 type AuthenticationRequest struct {
-	Method AuthenticationMethod
-	Salt   []byte
+	Method                   AuthenticationMethod
+	Salt                     []byte
+	SupportedScramSHA256     bool
+	SupportedScramSHA256Plus bool
+	Message                  []byte
 }
 
 func (a *AuthenticationRequest) server() {}
@@ -57,16 +67,13 @@ func ParseAuthenticationRequest(r io.Reader) (*AuthenticationRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	m := AuthenticationMethod(i)
-	if m != AuthenticationMethodOK && m != AuthenticationMethodPlaintext && m != AuthenticationMethodMD5 {
-		return nil, fmt.Errorf("received unknown authentication request method number %d", m)
-	}
-
-	a := &AuthenticationRequest{
-		Method: m,
-	}
-
-	if a.Method == AuthenticationMethodMD5 {
+	switch m := AuthenticationMethod(i); m {
+	case AuthenticationMethodOK, AuthenticationMethodPlaintext:
+		return &AuthenticationRequest{Method: m}, nil
+	case AuthenticationMethodMD5:
+		a := &AuthenticationRequest{
+			Method: m,
+		}
 		a.Salt, err = buf.ReadString(false)
 		if err != nil {
 			return nil, err
@@ -74,9 +81,44 @@ func ParseAuthenticationRequest(r io.Reader) (*AuthenticationRequest, error) {
 		if len(a.Salt) != 4 {
 			return nil, fmt.Errorf("expected salt of length 4")
 		}
-	}
+		return a, nil
+	case AuthenticationMethodSASL:
+		a := &AuthenticationRequest{
+			Method: m,
+		}
 
-	return a, nil
+		for {
+			supportedSaslMechanism, err := buf.ReadString(true)
+			if err != nil {
+				return nil, err
+			}
+			switch string(supportedSaslMechanism) {
+			case SASLMechanismScramSHA256:
+				a.SupportedScramSHA256 = true
+			case SASLMechanismScramSHA256Plus:
+				a.SupportedScramSHA256Plus = true
+			case "":
+				return a, nil
+			default:
+				return nil, fmt.Errorf("server supports unknown SASL mechanism")
+			}
+		}
+	case AuthenticationMethodSASLContinue, AuthenticationMethodSASLFinal:
+
+		message, err := buf.ReadString(true)
+		if err != nil {
+			return nil, err
+		}
+		a := &AuthenticationRequest{
+			Method:  m,
+			Message: message,
+		}
+
+		return a, nil
+
+	default:
+		return nil, fmt.Errorf("received unknown authentication request method number %d", m)
+	}
 }
 
 // Encode will return the byte representation of this AuthenticationRequest message
@@ -84,9 +126,21 @@ func (a *AuthenticationRequest) Encode() []byte {
 	// 'R' [int32 - length] [int32 - method] [other - optional]
 	w := newWriteBuffer()
 	w.WriteInt(int(a.Method))
-	if a.Method == AuthenticationMethodMD5 {
+	switch a.Method {
+	case AuthenticationMethodMD5:
 		w.WriteString(a.Salt, false)
+	case AuthenticationMethodSASL:
+		if a.SupportedScramSHA256 {
+			w.WriteString([]byte(SASLMechanismScramSHA256), true)
+		}
+		if a.SupportedScramSHA256Plus {
+			w.WriteString([]byte(SASLMechanismScramSHA256Plus), true)
+		}
+		w.WriteByte('\x00')
+	case AuthenticationMethodSASLContinue, AuthenticationMethodSASLFinal, AuthenticationMethodOK:
+		w.WriteBytes(a.Message)
 	}
+
 	w.Wrap('R')
 	return w.Bytes()
 }
@@ -98,14 +152,20 @@ func (a *AuthenticationRequest) Encode() []byte {
 //     "Payload": map[string]interface{}{
 //       "Method": <AuthenticationRequest.Method>,
 //       "Salt": <AuthenticationRequest.Salt>,
+//       "ScramSHA256": <AuthenticationRequest.ScramSHA256>,
+//       "ScramSHA256Plus": <AuthenticationRequest.ScramSHA256Plus>,
+//       "Message": <AuthenticationRequest.Message>,
 //     },
 //   }
 func (a *AuthenticationRequest) AsMap() map[string]interface{} {
 	return map[string]interface{}{
 		"Type": "AuthenticationRequest",
 		"Payload": map[string]interface{}{
-			"Method": int(a.Method),
-			"Salt":   a.Salt,
+			"Method":          int(a.Method),
+			"Salt":            a.Salt,
+			"ScramSHA256":     a.SupportedScramSHA256,
+			"ScramSHA256Plus": a.SupportedScramSHA256Plus,
+			"Message":         a.Message,
 		},
 	}
 }

--- a/error.go
+++ b/error.go
@@ -124,7 +124,7 @@ func encodeError(e *Error, tag byte) []byte {
 func errorMap(e *Error, name string) map[string]interface{} {
 	return map[string]interface{}{
 		"Type": name,
-		"Payload": map[string]string{
+		"Payload": map[string]interface{}{
 			"Severity": string(e.Severity),
 			"Text":     string(e.Text),
 			"Code":     string(e.Code),

--- a/password.go
+++ b/password.go
@@ -6,10 +6,23 @@ import (
 )
 
 type PasswordMessage struct {
-	Password []byte
+	HeaderMessage []byte
+	BodyMessage   []byte
 }
 
 func (p *PasswordMessage) client() {}
+
+// SASLResponse (F)
+// Byte1('p') Identifies the message as a SASL response.
+// Int32 Length of message contents in bytes, including self.
+// Byten SASL mechanism specific message data.
+
+// SASLInitialResponse (F)
+// Byte1('p') Identifies the message as an initial SASL response.
+// Int32 Length of message contents in bytes, including self.
+// String Name of the SASL authentication mechanism that the client selected.
+// Int32 Length of SASL mechanism specific "Initial Client Response" that follows, or -1 if there is no Initial Response.
+// Byten SASL mechanism specific "Initial Response".
 
 func ParsePasswordMessage(r io.Reader) (*PasswordMessage, error) {
 	b := newReadBuffer(r)
@@ -24,40 +37,92 @@ func ParsePasswordMessage(r io.Reader) (*PasswordMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	p := &PasswordMessage{}
-
-	p.Password, err = buf.ReadString(true)
+	message, err := buf.ReadString(false)
 	if err != nil {
 		return nil, err
 	}
+	headerMessage := bytes.TrimRight(message, "\x00")
 
-	return p, nil
+	_, err = buf.ReadInt()
+
+	if err == io.EOF {
+		// in case of PasswordMessage and SASLResponse
+		// we have not any data in buffer
+		if bytes.Equal(message, headerMessage) {
+			// SASLResponse
+			return &PasswordMessage{BodyMessage: message}, nil
+		}
+		// PasswordMessage
+		return &PasswordMessage{HeaderMessage: headerMessage}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	bodyMessage, err := buf.ReadString(false)
+	if err != nil {
+		return nil, err
+	}
+	return &PasswordMessage{HeaderMessage: headerMessage, BodyMessage: bodyMessage}, nil
 }
 
 func (p *PasswordMessage) PasswordValid(user []byte, password []byte, salt []byte) bool {
 	hash := HashPassword(user, password, salt)
-	return bytes.Equal(p.Password, hash)
+	return bytes.Equal(p.HeaderMessage, hash)
 }
 
 func (p *PasswordMessage) SetPassword(user []byte, password []byte, salt []byte) {
-	p.Password = HashPassword(user, password, salt)
+	p.HeaderMessage = HashPassword(user, password, salt)
 }
 
 func (p *PasswordMessage) Encode() []byte {
+	// PasswordMessage
 	// 'p' [int32 - length] [string] \0
+	//
+	// SASLInitialResponse
+	// 'p' [int32 - length] [string] [int32 - length] []byte
+	//
+	// SASLResponse
+	// 'p' [int32 - length] []byte
 	w := newWriteBuffer()
-	w.WriteString(p.Password, true)
+	if len(p.HeaderMessage) > 0 {
+		// PasswordMessage and SASLInitialResponse
+		w.WriteString(p.HeaderMessage, true)
+	}
+	if len(p.BodyMessage) > 0 {
+		if len(p.HeaderMessage) > 0 {
+			// SASLInitialResponse
+			w.WriteInt(len(p.BodyMessage))
+		}
+		// SASLResponse
+		w.WriteBytes(p.BodyMessage)
+	}
 	w.Wrap('p')
 	return w.Bytes()
 }
 
 func (p *PasswordMessage) AsMap() map[string]interface{} {
+	if len(p.BodyMessage)*len(p.HeaderMessage) > 0 {
+		return map[string]interface{}{
+			"Type": "SASLInitialResponse",
+			"Payload": map[string]interface{}{
+				"Mechanism": p.HeaderMessage,
+				"Message":   p.BodyMessage,
+			},
+		}
+	}
+	if len(p.BodyMessage) > 0 {
+		return map[string]interface{}{
+			"Type": "SASLResponse",
+			"Payload": map[string]interface{}{
+				"Message": p.BodyMessage,
+			},
+		}
+	}
 	return map[string]interface{}{
 		"Type": "PasswordMessage",
 		"Payload": map[string]interface{}{
-			"Password": p.Password,
+			"Password": p.HeaderMessage,
 		},
 	}
 }
+
 func (p *PasswordMessage) String() string { return messageToString(p) }

--- a/ssl.go
+++ b/ssl.go
@@ -1,0 +1,32 @@
+package pgproto
+
+import (
+	"io"
+)
+
+type SSLRequest struct {
+}
+
+func (s *SSLRequest) client() {}
+
+func ParseSSLResponse(r io.Reader) error {
+	b := newReadBuffer(r)
+	return b.ReadTag('S')
+}
+
+func (s *SSLRequest) Encode() []byte {
+	// [int32 - length] []byte \0
+	//w := newWriteBuffer()
+	//w.WriteInt(sslRequestVersion)
+	//w.PrependLength()
+	return []byte{0x0, 0x0, 0x0, 0x8, 0x4, 0xd2, 0x16, 0x2f}
+}
+
+func (s *SSLRequest) AsMap() map[string]interface{} {
+	return map[string]interface{}{
+		"Type":    "SSLRequest",
+		"Payload": nil,
+	}
+}
+
+func (s *SSLRequest) String() string { return messageToString(s) }

--- a/utils.go
+++ b/utils.go
@@ -72,3 +72,14 @@ func messageToString(m Message) string {
 
 	return str + ">"
 }
+
+func ReadNBytes(r io.Reader, n int) ([]byte, error) {
+	expectedSlice := make([]byte, n)
+	for i := 0; i < n; i++ {
+		_, err := r.Read(expectedSlice[i : i+1])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return expectedSlice, nil
+}


### PR DESCRIPTION
> func ReadNBytes

I am facing the problem of reading a stream into a byte chunk of the full size of the pg message.
But it works fine with byte-by-byte reading. 
You can reproduce this error by running a multi-line query with 128+ KB response. 
Also I found that the problem occurs where the TCP length changes (from 8k to 32k bytes in my case).
![Screenshot from 2021-03-03 00-09-16](https://user-images.githubusercontent.com/1041304/111233348-1e7a3180-85ed-11eb-8141-2e596fb13024.png)


> func ParseClientMessage / ParseServerMessage

small refactoring, and we pass the prepared message to the parsing functions.

> errorMap: 

changed the struct for correct parsing by the messageToString function

Added:
 - SSLRequest
 - SASL messages
